### PR TITLE
Aligning to angular's $http API

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ $httpoll.get('/some_resource', {retries: 50, delay: 20})
 $httpoll.post('/some_resource', {resource: {...}}, {retryOnError: true})
 ```
 
+### Provider
+
+By default, `$httpoll` uses angular's `$http` service as its provider. However, you may change this using the `provider` method. This is especially useful for mocking requests in testing, but could theoretically be used to integrate another HTTP service provider.
+
+#### Example
+
+```javascript
+$httpoll.provider = mockHttpProviderFunction
+```
+
 
 ## Development and Testing
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ angular.module('YourModule',['ngHTTPPoll'])
 
 ### Config Options
 
-`$httpoll` wraps Angular's [`$http`](https://docs.angularjs.org/api/ng/service/$http) methods, polling the endpoint multiple times, based on the kind of behavior you configure. The API is the same for all `$http` methods, except that it accepts additional config variables:
+`$httpoll` wraps Angular's [`$http`](https://docs.angularjs.org/api/ng/service/$http) methods, polling the endpoint multiple times, based on the kind of behavior you configure. The API is the same for `$http`, except that it accepts additional keys in the config object:
 
 - `retries` [integer] The maximum number of retries that the poller will attempt until it receives a status code in either the `successRange` or `errorRange` _(default: 50)_
 - `delay` [integer] Time (in milliseconds) to delay the next retry after a response is received _(default: 100)_
@@ -39,6 +39,15 @@ angular.module('YourModule',['ngHTTPPoll'])
 #### Examples
 
 ```javascript
+
+// A GET request with only 10 retries
+$httpoll({
+    url: '/some_resource/123',
+    method: 'GET',
+    data: {resource: {...}},
+    retries: 10
+})
+
 // A GET request that retries 50 times, with 200ms between each response/request
 $httpoll.get('/some_resource', {retries: 50, delay: 20})
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ $httpoll.post('/some_resource', {resource: {...}}, {retryOnError: true})
 
 ### Provider
 
-By default, `$httpoll` uses angular's `$http` service as its provider. However, you may change this using the `provider` method. This is especially useful for mocking requests in testing, but could theoretically be used to integrate another HTTP service provider.
+By default, `$httpoll` uses angular's `$http` service to make HTTP requests. However, you may change this using the `provider` method. This is especially useful for mocking requests in testing, but could theoretically be used to integrate another HTTP service provider. The provider should accept a configuration object as its sole argument.
 
 #### Example
 
 ```javascript
 $httpoll.provider = mockHttpProviderFunction
 ```
+
+**Note:** Changing providers will break the HTTP shortcut methods unless the config object for the custom provider is the same as $http.
 
 
 ## Development and Testing

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function pollingService($http, $timeout) {
 
     /* generates public methods on the poller for each $http method */
     for (var method in HTTP_METHODS) {
-        var hasBody = !!HTTP_METHODS[method].body;
+        var hasBody = HTTP_METHODS[method].body;
         poller[method] = generatePollingFunction(method, hasBody)
     }
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,9 @@ function pollingService($http, $timeout) {
     var poller = function (config) {
         var config = getConfig(config);
 
+        // allows overriding of the $http service, useful for testing
+        var httpProvider = poller.provider || $http;
+
         if (config.timeout && !config.timeoutId) {
             timeoutIdCounter ++;
             config.timeoutId = timeoutIdCounter;
@@ -41,7 +44,7 @@ function pollingService($http, $timeout) {
             }, config.timeout);
         }
 
-        return poller.$http(config)
+        return httpProvider(config)
             .then(pollResponse, pollResponse);
 
         function pollResponse(response){
@@ -60,8 +63,6 @@ function pollingService($http, $timeout) {
         }
 
     };
-
-    poller.$http = $http;
 
     /* generates public methods on the poller for each $http method */
     for (var method in HTTP_METHODS) {

--- a/test/httpoll.spec.js
+++ b/test/httpoll.spec.js
@@ -164,10 +164,11 @@ describe('$httpoll service', function () {
     }
 
     function $httpSpy () {
-        spyOn($httpoll,'$http').and.callThrough();
+        $httpoll.provider = $http;
+        spyOn($httpoll,'provider').and.callThrough();
     }
 
     function expectHTTPCount(count){
-        expect($httpoll.$http.calls.count()).toBe(count)
+        expect($httpoll.provider.calls.count()).toBe(count)
     }
 })

--- a/test/httpoll.spec.js
+++ b/test/httpoll.spec.js
@@ -134,6 +134,12 @@ describe('$httpoll service', function () {
                     expectHTTPCount(5)
                 }
             )
+
+            it ('should not mutate the original config object', function() {
+                var config = {retries: 20};
+                var promise = $httpoll[method](route, {}, config);
+                expect(config).toEqual({retries: 20});
+            });
         })
     });
 


### PR DESCRIPTION
This PR attempts to align the `$httpoll` more closely with angular's `$http`.

It also allows injection of HTTP providers that are not `$http`, mostly for easier mocking in the tests.

Also, DRYed up the tests with some more helper methods.