### PR TITLE
returns response instead of just the data

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function pollingService($http, $timeout, $q) {
             }
 
             if (inSuccessRange(response.status, config)) {
-                return response.data;
+                return response;
             }
 
             if (state.remaining <= 0) {

--- a/test/httpoll.spec.js
+++ b/test/httpoll.spec.js
@@ -113,7 +113,7 @@ describe('$httpoll service', function () {
                 function () {
                     var promise = $httpoll[method](route);
                     promise.then(function(r){
-                        expect(r).toBe(response);
+                        expect(r.data).toBe(response);
                     })
                     flush();
                     expectHTTPCount(5)
@@ -137,7 +137,7 @@ describe('$httpoll service', function () {
                     var payload = {foo: 'bar'};
                     var promise = $httpoll[method](route, payload);
                     promise.then(function(r){
-                        expect(r).toEqual(payload);
+                        expect(r.data).toEqual(payload);
                     })
                     flush();
                     expectHTTPCount(5)


### PR DESCRIPTION
Polling returns the full response object, not just the response body so that a user can inspect the last response.