### PR TITLE
Continue/Until

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ angular.module('YourModule',['ngHTTPPoll'])
 - `timeout` [integer] Timeout for polling - no further retries will be attempted. A false-y value means that the poller will never timeout. _(default: false)_
 - `successRange` [array]: A range of HTTP status codes that the poller should interpret as a success _(default: [200, 201])_
 - `errorRange` [array]: A range of HTTP status codes that the poller should interpret as errors _(default: [400, 599])_
+- `continue` [function(response, config, state)]: Contine fires after every request. Polling will continue as long as this function returns a truth-y value (or unless polling time exceeds the set `timeout`).
+- `until` [function(response, config, state)]: Until fires after every request. Polling will stop when this function returns a truth-y value (or unless polling time exceeds the set `timeout`).
+
+
+**Note**: An error thrown from within the `continue` or `until` functions will stop polling, and the error's message will be sent to a `catch` function, if defined.
 
 #### Examples
 

--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ function pollingService($http, $timeout, $q) {
         timeout: false,
         successRange: [200, 201],
         errorRange: [400, 599],
-        continue: defaultContinue
+        continue: defaultContinue,
+        until: null
     }
 
     /* polls an API based on settings */
@@ -53,7 +54,9 @@ function pollingService($http, $timeout, $q) {
 
         function pollResponse(response){
             try {
-                if (config.continue(response, config, state)) {
+                if ((config.until && !config.until(response, config, state)) ||
+                    config.continue(response, config, state)) {
+
                     state.remaining -= 1;
                     return $timeout(function(){
                         if (timeoutStatuses[state.timeoutId]) {

--- a/test/httpoll.spec.js
+++ b/test/httpoll.spec.js
@@ -111,15 +111,43 @@ describe('$httpoll service', function () {
             expectHTTPCount(1);
         })
 
+
+        it ('should override until if timeout is set', function() {
+            var result = $httpoll({
+                method: 'get',
+                url: route,
+                timeout: 1000,
+                delay: 1200,
+                retries: 9,
+                until: function(){
+                    return false;
+                }
+            })
+            expectTimeout(result);
+            expectHTTPCount(1);
+        })
+
         it ('should continue polling if condition is satisfied', function (){
             var result = $httpoll({
                 method: 'get',
                 url: route,
                 retries: 9,
-                continue: function continueFunction (response, config, state) {
+                continue: function (response, config, state) {
                     return state.remaining > 3;
-                },
-                test: true
+                }
+            });
+            flush();
+            expectHTTPCount(7);
+        })
+
+        it ('should continue polling until condition is satisfied', function (){
+            var result = $httpoll({
+                method: 'get',
+                url: route,
+                retries: 9,
+                until: function (response, config, state) {
+                    return state.remaining < 4;
+                }
             });
             flush();
             expectHTTPCount(7);


### PR DESCRIPTION
Adds two new options: `continue` and `until` which override default behavior for when to stop polling.