### PR TITLE
Until Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ angular.module('YourModule',['ngHTTPPoll'])
 - `state`: Gives access to the current state of polling
     - `retryCount`: The number of retries that have already been performed
 - `actions`:
-    - `pass` [function()]: Calls the default `until` logic
+    - `default` [function()]: Calls the default `until` logic
     - `reConfig` [function(config)]: Overrides the config values for future requests
 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,19 @@ angular.module('YourModule',['ngHTTPPoll'])
 - `timeout` [integer] Timeout for polling - no further retries will be attempted. A false-y value means that the poller will never timeout. _(default: false)_
 - `successRange` [array]: A range of HTTP status codes that the poller should interpret as a success _(default: [200, 201])_
 - `errorRange` [array]: A range of HTTP status codes that the poller should interpret as errors _(default: [400, 599])_
-- `until` [function(response, config, state)]: Until fires after every request. Polling will stop when this function returns a truth-y value (or unless polling time exceeds the set `timeout`). An error thrown from within the`until` function will stop polling, and the error's message will be sent to a `catch` function, if defined.
+- `until` [function(response, config, state, actions)]: Until fires after every request. Polling will stop when this function returns a truth-y value (or unless polling time exceeds the set `timeout`). An error thrown from within the`until` function will stop polling, and the error's message will be sent to a `catch` function, if defined.
+
+### Until Parameters
+
+- `response`: The last response from the HTTP provider
+- `config`: The current config values
+- `state`: Gives access to the current state of polling
+    - `retryCount`: The number of retries that have already been performed
+- `actions`:
+    - `pass` [function()]: Calls the default `until` logic
+    - `reConfig` [function(config)]: Overrides the config values for future requests
+
+
 
 #### Examples
 

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function pollingService($http, $timeout, $q) {
                 var untilFunc = config.until || defaultUntil;
                 // deep-copy config prevents overriding config values
                 var untilConfig = angular.copy(config);
-                if (untilFunc(response, config, state, actions)) {
+                if (untilFunc(response, untilConfig, state, actions)) {
                     return response;
                 } else {
                     state.retryCount += 1;

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function pollingService($http, $timeout, $q) {
 
             var actions = {
                 // apply default `until` logic
-                pass: function() {
+                default: function() {
                     return defaultUntil(response, config, state)
                 },
                 // overrides config for subsequent requests

--- a/test/httpoll.spec.js
+++ b/test/httpoll.spec.js
@@ -1,6 +1,7 @@
 describe('$httpoll service', function () {
     var $httpoll, $httpBackend, $http, $timeout, pollingIterations;
     var route = '/';
+    var retries = 5;
 
     beforeEach(module('ngHTTPPoll'));
 
@@ -19,10 +20,7 @@ describe('$httpoll service', function () {
 
     describe('main method', function () {
 
-        var retries;
-
         beforeEach(function(){
-            retries = 5;
             mockPollResponse('get', route, retries, "response");
         })
 
@@ -45,7 +43,7 @@ describe('$httpoll service', function () {
         it ('should retry if it receives a status code in the error range',
             function() {
                 $httpoll({method: 'get', url: route, retryOnError: true })
-                expectHTTPCount(5)
+                expectSuccess()
             }
         )
 
@@ -67,7 +65,7 @@ describe('$httpoll service', function () {
                 errorRange: [500, 599],
                 retryOnError: false
             })
-            expectHTTPCount(5)
+            expectSuccess()
         })
 
         it ('should respect a custom success range', function() {
@@ -130,7 +128,7 @@ describe('$httpoll service', function () {
                         return actions.default();
                     }
                 });
-                expectHTTPCount(5);
+                expectSuccess()
             });
 
             it ('should reset config for future requests', function () {
@@ -157,7 +155,6 @@ describe('$httpoll service', function () {
 
         describe (method+' method', function () {
             var response = "response message";
-            var retries = 5;
             beforeEach(function(){
                 mockPollResponse(method, route, retries, response)
             });
@@ -168,7 +165,7 @@ describe('$httpoll service', function () {
                     promise.then(function(r){
                         expect(r.data).toBe(response);
                     })
-                    expectHTTPCount(5)
+                    expectSuccess()
                 }
             );
         });
@@ -178,7 +175,6 @@ describe('$httpoll service', function () {
     ['put','post','patch'].forEach(function(method){
 
         describe (method+' method', function () {
-            var retries = 5;
             beforeEach(function(){
                 mockPollResponse(method, route, retries, "", true)
             });
@@ -191,7 +187,7 @@ describe('$httpoll service', function () {
                     promise.then(function(r){
                         expect(r.data).toEqual(payload);
                     })
-                    expectHTTPCount(5)
+                    expectSuccess()
                 }
             )
 
@@ -257,5 +253,9 @@ describe('$httpoll service', function () {
     function expectHTTPCount(count){
         flush();
         expect($httpoll.provider.calls.count()).toBe(count)
+    }
+
+    function expectSuccess() {
+        expectHTTPCount(retries);
     }
 })

--- a/test/httpoll.spec.js
+++ b/test/httpoll.spec.js
@@ -121,13 +121,13 @@ describe('$httpoll service', function () {
                 expectHTTPCount(7);
             })
 
-            it ('should defer to default logic', function () {
+            it ('should use the "default" option defer to default logic', function () {
                 var result = $httpoll({
                     method: 'get',
                     url: route,
                     retries: 9,
                     until: function (response, config, state, actions) {
-                        return actions.pass();
+                        return actions.default();
                     }
                 });
                 expectHTTPCount(5);
@@ -142,7 +142,7 @@ describe('$httpoll service', function () {
                         actions.reConfig({
                             retries: 2
                         });
-                        return actions.pass();
+                        return actions.default();
                     }
                 });
                 expectHTTPCount(3);


### PR DESCRIPTION
Adds `actions` parameter to the `until` function that gives user access to methods that do the following:

`reConfig`: changes the config options for future requests
`pass`: defers to the default `until` functionality