### PR TITLE
Actions not passed to defaultUntil

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function pollingService($http, $timeout, $q) {
             var actions = {
                 // apply default `until` logic
                 default: function() {
-                    return defaultUntil(response, config, state)
+                    return defaultUntil(response, config, state, actions)
                 },
                 // overrides config for subsequent requests
                 reConfig: function (overrideConfig) {


### PR DESCRIPTION
Fixed a bug where `actions` was not passed to defaultUntil if called in the context of the `until` block.